### PR TITLE
Fix node version on publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '20'
+          node-version: '20'
       - run: npm ci
       - run: npm run build
       - uses: JS-DevTools/npm-publish@v3


### PR DESCRIPTION
Workflow failed because of the use of `node-version-file` instead of `node-version`