### PR TITLE
Rename dai token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hemilabs/token-list",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "List of ERC-20 tokens in the Hemi Network chains",
   "bugs": {
     "url": "https://github.com/hemilabs/token-list/issues"

--- a/src/hemi.tokenlist.json
+++ b/src/hemi.tokenlist.json
@@ -12,7 +12,7 @@
       "chainId": 743111,
       "decimals": 18,
       "logoURI": "https://raw.githubusercontent.com/ethereum-optimism/ethereum-optimism.github.io/master/data/DAI/logo.svg",
-      "name": "Hemi Tunneled DAI",
+      "name": "DAI",
       "symbol": "DAI",
       "extensions": {
         "birthBlock": 71589,


### PR DESCRIPTION
As part of making tokens to be named the same as their L1 counterpart, I'm renaming "Hemi Tunneled DAI" to just "DAI"