### PR TITLE
Fix chainlink name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hemilabs/token-list",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hemilabs/token-list",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "19.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hemilabs/token-list",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "List of ERC-20 tokens in the Hemi Network chains",
   "bugs": {
     "url": "https://github.com/hemilabs/token-list/issues"

--- a/src/hemi.tokenlist.json
+++ b/src/hemi.tokenlist.json
@@ -4,7 +4,7 @@
   "version": {
     "major": 1,
     "minor": 1,
-    "patch": 0
+    "patch": 1
   },
   "tokens": [
     {

--- a/src/hemi.tokenlist.json
+++ b/src/hemi.tokenlist.json
@@ -175,7 +175,7 @@
         }
       },
       "logoURI": "https://raw.githubusercontent.com/hemilabs/token-list/master/src/logos/link.svg",
-      "name": "ChainLink",
+      "name": "Chainlink",
       "symbol": "LINK"
     },
     {


### PR DESCRIPTION
Closes #10 


`ChainLink` is renamed to `Chainlink`, the appropriate name