### PR TITLE
Add weth mainnet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hemilabs/token-list",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hemilabs/token-list",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "19.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hemilabs/token-list",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "List of ERC-20 tokens in the Hemi Network chains",
   "bugs": {
     "url": "https://github.com/hemilabs/token-list/issues"

--- a/src/hemi.tokenlist.json
+++ b/src/hemi.tokenlist.json
@@ -3,8 +3,8 @@
   "timestamp": "2024-05-07T22:03:02.686Z",
   "version": {
     "major": 1,
-    "minor": 1,
-    "patch": 1
+    "minor": 2,
+    "patch": 0
   },
   "tokens": [
     {

--- a/src/hemi.tokenlist.json
+++ b/src/hemi.tokenlist.json
@@ -273,6 +273,14 @@
       "logoURI": "https://raw.githubusercontent.com/hemilabs/token-list/master/src/logos/comp.svg",
       "name": "Compound",
       "symbol": "COMP"
+    },
+    {
+      "address": "0x4200000000000000000000000000000000000006",
+      "chainId": 43111,
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/hemilabs/token-list/master/src/logos/weth.svg",
+      "name": "Wrapped Ether",
+      "symbol": "WETH"
     }
   ]
 }

--- a/src/hemi.tokenlist.json
+++ b/src/hemi.tokenlist.json
@@ -27,7 +27,7 @@
       "address": "0x0C8aFD1b58aa2A5bAd2414B861D8A7fF898eDC3A",
       "chainId": 743111,
       "decimals": 18,
-      "logoURI": "https://raw.githubusercontent.com/ethereum-optimism/ethereum-optimism.github.io/master/data/WETH/logo.png",
+      "logoURI": "https://raw.githubusercontent.com/hemilabs/token-list/master/src/logos/weth.svg",
       "name": "Wrapped Ether",
       "symbol": "WETH",
       "extensions": {


### PR DESCRIPTION
Closes #13 

- e7a21bfe3d8225ccb4ee7eff90302d0bdd95da39 Updates the `WETH` logo to use the local one defined in this repo instead of the Optimism one.
- 37a5dec7d3ed11597728ebb6855da104af7b89c8 Adds the WETH token defined in Mainnet
- 5f00fcbb8d9d4cf57ceaa24dd6409f39b4b354f2 Bumps the version