### PR TITLE
Add missing permission

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,5 +7,7 @@ on:
 
 jobs:
   npm-publish:
-    uses: hemilabs/actions/.github/workflows/npm-publish.yml@main
+    permissions:
+      id-token: write
     secrets: inherit
+    uses: hemilabs/actions/.github/workflows/npm-publish.yml@main

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hemilabs/token-list",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hemilabs/token-list",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "19.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hemilabs/token-list",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "List of ERC-20 tokens in the Hemi Network chains",
   "bugs": {
     "url": "https://github.com/hemilabs/token-list/issues"

--- a/src/hemi.tokenlist.json
+++ b/src/hemi.tokenlist.json
@@ -1,6 +1,6 @@
 {
   "name": "Hemi Token List",
-  "timestamp": "2025-01-03T18:53:03.571Z",
+  "timestamp": "2025-01-06T17:56:39.408Z",
   "version": {
     "major": 1,
     "minor": 4,

--- a/src/hemi.tokenlist.json
+++ b/src/hemi.tokenlist.json
@@ -1,10 +1,10 @@
 {
   "name": "Hemi Token List",
-  "timestamp": "2025-01-06T17:56:39.408Z",
+  "timestamp": "2025-01-06T17:56:44.961Z",
   "version": {
     "major": 1,
     "minor": 4,
-    "patch": 0
+    "patch": 1
   },
   "tokens": [
     {


### PR DESCRIPTION
After https://github.com/hemilabs/actions/pull/15 it turns out that the caller also needs to add the permission to `id-token: write`.

See https://github.com/orgs/community/discussions/76409  and https://github.com/orgs/community/discussions/76409#discussioncomment-11260212