### PR TITLE
Add missing contents read permission

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   npm-publish:
     permissions:
+      contents: read
       id-token: write
     secrets: inherit
     uses: hemilabs/actions/.github/workflows/npm-publish.yml@main

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hemilabs/token-list",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hemilabs/token-list",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "19.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hemilabs/token-list",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "List of ERC-20 tokens in the Hemi Network chains",
   "bugs": {
     "url": "https://github.com/hemilabs/token-list/issues"

--- a/src/hemi.tokenlist.json
+++ b/src/hemi.tokenlist.json
@@ -1,10 +1,10 @@
 {
   "name": "Hemi Token List",
-  "timestamp": "2025-01-06T19:09:38.941Z",
+  "timestamp": "2025-01-06T19:09:48.116Z",
   "version": {
     "major": 1,
     "minor": 4,
-    "patch": 1
+    "patch": 2
   },
   "tokens": [
     {

--- a/src/hemi.tokenlist.json
+++ b/src/hemi.tokenlist.json
@@ -1,6 +1,6 @@
 {
   "name": "Hemi Token List",
-  "timestamp": "2025-01-06T17:56:44.961Z",
+  "timestamp": "2025-01-06T19:09:38.941Z",
   "version": {
     "major": 1,
     "minor": 4,


### PR DESCRIPTION
According to [GitHub](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idpermissions)

> For each of the available permissions, shown in the table below, you can assign one of the access levels: read (if applicable), write, or none. write includes read. If you specify the access for any of these permissions, all of those that are not specified are set to none.

So I now need to add `contents: read` as well after #22 . There are no more permissions required