### PR TITLE
Validate token list schema

### DIFF
--- a/.github/workflows/js-checks.yml
+++ b/.github/workflows/js-checks.yml
@@ -8,18 +8,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
-# The reusable workflow at bloq/actions/.github/workflows/js-checks.yml@v1
-# cannot be used as environment variables must be sent to the test command to
-# overwrite the EVM RPC URL of Hemi mainnet. When this is not needed anymore,
-# the custom workflow should be replaced by the reusable one.
-
 jobs:
   js-checks:
     uses: hemilabs/actions/.github/workflows/js-checks.yml@main
-
-  validate-list:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: hemilabs/actions/setup-node-env@main
-      - run: npm run schema:validate

--- a/.github/workflows/js-checks.yml
+++ b/.github/workflows/js-checks.yml
@@ -10,4 +10,4 @@ concurrency:
 
 jobs:
   js-checks:
-    uses: hemilabs/actions/.github/workflows/js-checks.yml@main
+    uses: hemilabs/actions/.github/workflows/js-checks.yml@01a748b9e1b966ae64d2a7b146ff7e4700dc1da5

--- a/.github/workflows/js-checks.yml
+++ b/.github/workflows/js-checks.yml
@@ -15,23 +15,11 @@ concurrency:
 
 jobs:
   js-checks:
+    uses: hemilabs/actions/.github/workflows/js-checks.yml@main
+
+  validate-list:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bloq/actions/setup-node-env@v1
-        with:
-          cache: npm
-      - run: npm run --if-present format:check
-      - run: npm run --if-present lint
-      - run: npm run --if-present deps:check
-  run-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: bloq/actions/setup-node-env@v1
-        with:
-          cache: npm
-      - run: npm run test
-        env:
-          EVM_RPC_URL_43111: ${{ secrets.EVM_RPC_URL_43111 }}
-          EVM_RPC_URL_743111: ${{ secrets.WEB3_RPC_743111 }}
+      - uses: hemilabs/actions/setup-node-env@main
+      - run: npm run schema:validate

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "19.5.0",
+        "ajv": "8.17.1",
+        "ajv-formats": "3.0.1",
         "better-sort-package-json": "1.1.0",
         "commitlint-config-bloq": "1.1.0",
         "eslint": "8.57.1",
@@ -895,6 +897,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -904,6 +907,24 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-escapes": {

--- a/package.json
+++ b/package.json
@@ -22,11 +22,14 @@
     "format:check": "prettier --check .",
     "lint": "eslint --cache .",
     "prepare": "husky",
+    "schema:validate": "node scripts/validate-list.js",
     "test": "node --test",
     "version": "node scripts/sync-version.js && git add ."
   },
   "devDependencies": {
     "@commitlint/cli": "19.5.0",
+    "ajv": "8.17.1",
+    "ajv-formats": "3.0.1",
     "better-sort-package-json": "1.1.0",
     "commitlint-config-bloq": "1.1.0",
     "eslint": "8.57.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint": "eslint --cache .",
     "prepare": "husky",
     "schema:validate": "node scripts/validate-list.js",
+    "pretest": "npm run schema:validate",
     "test": "node --test",
     "version": "node scripts/sync-version.js && git add ."
   },

--- a/scripts/validate-list.js
+++ b/scripts/validate-list.js
@@ -1,0 +1,36 @@
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import fs from "node:fs";
+import { exit } from "node:process";
+
+// eslint fails to parse "with { type: "json" }"
+// See https://github.com/eslint/eslint/discussions/15305
+const tokenList = JSON.parse(fs.readFileSync("./src/hemi.tokenlist.json"));
+
+const schemaUrl =
+  "https://raw.githubusercontent.com/Uniswap/token-lists/main/src/tokenlist.schema.json";
+
+// See https://github.com/uniswap/token-lists?tab=readme-ov-file#validating-token-lists
+async function validate() {
+  const ajv = new Ajv({ allErrors: true, verbose: true });
+  addFormats(ajv);
+  const schema = await fetch(schemaUrl).then((r) => r.json());
+  const validator = ajv.compile(schema);
+  const valid = validator(tokenList);
+  if (valid) {
+    return;
+  }
+  if (validator.errors) {
+    throw validator.errors.map(function (error) {
+      delete error.data;
+      return error;
+    });
+  }
+}
+
+validate()
+  .then(() => console.info("Schema is valid"))
+  .catch(function (err) {
+    console.error(err);
+    exit();
+  });

--- a/scripts/validate-list.js
+++ b/scripts/validate-list.js
@@ -21,10 +21,7 @@ async function validate() {
     return;
   }
   if (validator.errors) {
-    throw validator.errors.map(function (error) {
-      delete error.data;
-      return error;
-    });
+    throw validator.errors;
   }
 }
 

--- a/scripts/validate-list.js
+++ b/scripts/validate-list.js
@@ -32,5 +32,5 @@ validate()
   .then(() => console.info("Schema is valid"))
   .catch(function (err) {
     console.error(err);
-    exit();
+    exit(1);
   });

--- a/src/hemi.tokenlist.json
+++ b/src/hemi.tokenlist.json
@@ -1,6 +1,6 @@
 {
   "name": "Hemi Token List",
-  "timestamp": "2025-01-22T18:50:25.600Z",
+  "timestamp": "2025-01-22T19:35:30.684Z",
   "version": {
     "major": 1,
     "minor": 5,
@@ -299,7 +299,7 @@
     },
     {
       "address": "0x12B6e6FC45f81cDa81d2656B974E8190e4ab8D93",
-      "chainId": 43111,
+      "chainId": "43111",
       "decimals": 18,
       "extensions": {
         "bridgeInfo": {

--- a/src/hemi.tokenlist.json
+++ b/src/hemi.tokenlist.json
@@ -1,6 +1,6 @@
 {
   "name": "Hemi Token List",
-  "timestamp": "2025-01-22T18:36:21.416Z",
+  "timestamp": "2025-01-22T18:47:07.048Z",
   "version": {
     "major": 1,
     "minor": 5,

--- a/src/hemi.tokenlist.json
+++ b/src/hemi.tokenlist.json
@@ -1,6 +1,6 @@
 {
   "name": "Hemi Token List",
-  "timestamp": "2025-01-22T19:36:29.260Z",
+  "timestamp": "2025-01-22T20:42:04.584Z",
   "version": {
     "major": 1,
     "minor": 5,

--- a/src/hemi.tokenlist.json
+++ b/src/hemi.tokenlist.json
@@ -1,6 +1,6 @@
 {
   "name": "Hemi Token List",
-  "timestamp": "2025-01-22T19:35:30.684Z",
+  "timestamp": "2025-01-22T19:36:29.260Z",
   "version": {
     "major": 1,
     "minor": 5,
@@ -299,7 +299,7 @@
     },
     {
       "address": "0x12B6e6FC45f81cDa81d2656B974E8190e4ab8D93",
-      "chainId": "43111",
+      "chainId": 43111,
       "decimals": 18,
       "extensions": {
         "bridgeInfo": {

--- a/src/hemi.tokenlist.json
+++ b/src/hemi.tokenlist.json
@@ -1,6 +1,6 @@
 {
   "name": "Hemi Token List",
-  "timestamp": "2025-01-22T18:47:07.048Z",
+  "timestamp": "2025-01-22T18:50:25.600Z",
   "version": {
     "major": 1,
     "minor": 5,

--- a/src/hemi.tokenlist.json
+++ b/src/hemi.tokenlist.json
@@ -1,6 +1,6 @@
 {
   "name": "Hemi Token List",
-  "timestamp": "2025-01-16T15:25:35.973Z",
+  "timestamp": "2025-01-22T18:36:21.416Z",
   "version": {
     "major": 1,
     "minor": 5,


### PR DESCRIPTION
Closes #14

This PR adds a code that validates the schema of the token list is correct.

- dfb00c56a3b98b2b106929bd03e8d287bae74c22 adds such code, and afdc3aabfd09440facf28ec97facb85c4235ae80 adds the missing exit error code 😅 
- 68af6b1b70d5458ef7e6c25464161143b465a014 updates the GitHub actions as, after https://github.com/hemilabs/token-list/pull/21 we are no longer using the Env variables, so we can use our reusable workflows. It also adds an extra job to validate the schema of the token list.

(@gabmontes  we may want to remove those env variables if they are defined in this repo as they are no longer used)