### PR TITLE
Bump to 1.13.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hemilabs/token-list",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hemilabs/token-list",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "19.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hemilabs/token-list",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "List of ERC-20 tokens in the Hemi chains",
   "bugs": {
     "url": "https://github.com/hemilabs/token-list/issues"

--- a/src/hemi.tokenlist.json
+++ b/src/hemi.tokenlist.json
@@ -1,10 +1,10 @@
 {
   "name": "Hemi Token List",
-  "timestamp": "2025-03-12T13:46:06.897Z",
+  "timestamp": "2025-03-17T18:48:58.991Z",
   "version": {
     "major": 1,
     "minor": 13,
-    "patch": 0
+    "patch": 1
   },
   "tokens": [
     {


### PR DESCRIPTION
I was planning to bump after adding a new token, but since the smart contract verification failed, let's bump and get a chance to solve a different issue that depends on this update.

Closes #50 