### PR TITLE
Enable manual deploy to GHP

### DIFF
--- a/.github/workflows/deploy-to-ghp.yml
+++ b/.github/workflows/deploy-to-ghp.yml
@@ -1,6 +1,7 @@
 name: Deploy to GitHub Pages
 
 on:
+  workflow_dispatch:
   workflow_run:
     branches:
       - master


### PR DESCRIPTION
Forgot to add this trigger so we don't need to wait until a new release to deploy the site.