### PR TITLE
Move GHP deployment steps to a reusable action

### DIFF
--- a/.github/actions/deploy-to-ghp/action.yml
+++ b/.github/actions/deploy-to-ghp/action.yml
@@ -1,0 +1,37 @@
+name: Deploy to GitHub Pages
+
+author: Gabriel Montes
+
+description: Deploy a directory to GitHub Pages
+
+inputs:
+  build-with-npm:
+    description: Run NPM build script before deploying
+    default: "true"
+  publish-dir:
+    description: Directory to publish
+    default: public
+
+outputs:
+  page_url:
+    description: The URL of the deployed page
+    value: ${{ steps.deployment.outputs.page_url }}
+
+runs:
+  using: composite
+  steps:
+    - if: ${{ inputs.build-with-npm == 'true' }}
+      uses: hemilabs/actions/setup-node-env@v1
+    - run: npm run --if-present build
+      shell: sh
+      if: ${{ inputs.build-with-npm == 'true' }}
+    - uses: actions/configure-pages@v5
+    - uses: actions/upload-pages-artifact@v3
+      with:
+        path: ${{ inputs.publish-dir }}
+    - id: deployment
+      uses: actions/deploy-pages@v4
+
+branding:
+  color: orange
+  icon: book-open

--- a/.github/workflows/ghp-deploy.yml
+++ b/.github/workflows/ghp-deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: GitHub Pages Deployment
 
 on:
   workflow_dispatch:
@@ -8,15 +8,14 @@ on:
     types:
       - completed
     workflows:
-      - "NPM Publish"
+      - NPM Publish
 
 permissions:
-  contents: read
   id-token: write
   pages: write
 
 concurrency:
-  group: "pages"
+  group: pages
   cancel-in-progress: false
 
 jobs:
@@ -28,10 +27,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
-      - run: ./scripts/build-ghp.sh
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
-        with:
-          path: "public"
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: ./.github/actions/deploy-to-ghp
+        with:
+          build-with-npm: "true"
+          publish-dir: public
+    timeout-minutes: 2

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dist
 
 # GitHub Pages assets
 public
+
+# macOS Finder directory attributes
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "url": "git+https://github.com/hemilabs/token-list.git"
   },
   "scripts": {
+    "build": "scripts/build-ghp.sh",
     "format:check": "prettier --check .",
     "format:write": "prettier --write .",
     "lint": "eslint --cache .",


### PR DESCRIPTION
If this works, then we will move the reusable action to the "actions" repository.