### PR TITLE
FIx GitHub Pages deploy trigger

### DIFF
--- a/.github/workflows/ghp-deploy.yml
+++ b/.github/workflows/ghp-deploy.yml
@@ -3,8 +3,6 @@ name: GitHub Pages Deployment
 on:
   workflow_dispatch:
   workflow_run:
-    branches:
-      - master
     types:
       - completed
     workflows:


### PR DESCRIPTION
The "NPM Publish" workflow run is triggered on a tag/release, not on a branch. The deployment workflow condition was too restrictive and not being called.