### PR TITLE
Show L1 addresses when available

### DIFF
--- a/scripts/build-ghp-index.js
+++ b/scripts/build-ghp-index.js
@@ -22,6 +22,17 @@ const hemiExplorerUrl = (chainId, address) =>
 const etherscanUrl = (chainId, address) =>
   `https://${chainId === 1 ? "etherscan.io" : "sepolia.etherscan.io"}/token/${address}`;
 
+function addressLink(chainId, address) {
+  const url = [43111, 743111].includes(chainId)
+    ? hemiExplorerUrl(chainId, address)
+    : etherscanUrl(chainId, address);
+  return `
+<a class="font-mono text-neutral-500 hover:text-neutral-700" href="${url}" rel="noopener noreferrer" target="_blank" title="${address}">
+  ${shortenAddress(address)}
+</a>
+`;
+}
+
 function row({ address, chainId, extensions, logoURI, name, symbol }) {
   const chainName = chainId === 43111 ? "Hemi" : "Hemi Sepolia";
   const l1ChainId = chainId === 43111 ? 1 : 11155111;
@@ -36,18 +47,10 @@ function row({ address, chainId, extensions, logoURI, name, symbol }) {
   <td class="overflow-hidden whitespace-nowrap px-4 py-3 text-ellipsis">${symbol}</td>
   <td class="overflow-hidden whitespace-nowrap px-4 py-3 text-ellipsis">${chainName}</td>
   <td class="px-4 py-3">
-    <a class="font-mono text-neutral-500 hover:text-neutral-700" href="${hemiExplorerUrl(chainId, address)}" title="${address}">
-      ${shortenAddress(address)}
-    </a>
+    ${addressLink(chainId, address)}
   </td>
   <td class="hidden lg:table-cell px-4 py-3">
-    ${
-      l1Address
-        ? `<a class="font-mono text-neutral-500 hover:text-neutral-700" href="${etherscanUrl(l1ChainId, l1Address)}" title="${l1Address}">
-            ${shortenAddress(l1Address)}
-          </a>`
-        : "-"
-    }
+    ${l1Address ? addressLink(l1ChainId, l1Address) : "-"}
   </td>
 </tr>
 `;

--- a/scripts/build-ghp-index.js
+++ b/scripts/build-ghp-index.js
@@ -16,21 +16,41 @@ const logo = ({ logoURI, name }) => `
 const shortenAddress = (address) =>
   `${address.slice(0, 6)}...${address.slice(-4)}`;
 
-const row = ({ address, chainId, logoURI, name, symbol }) => `
+const hemiExplorerUrl = (chainId, address) =>
+  `https://${chainId === 43111 ? "explorer.hemi.xyz" : "testnet.explorer.hemi.xyz"}/token/${address}`;
+
+const etherscanUrl = (chainId, address) =>
+  `https://${chainId === 1 ? "etherscan.io" : "sepolia.etherscan.io"}/token/${address}`;
+
+function row({ address, chainId, extensions, logoURI, name, symbol }) {
+  const chainName = chainId === 43111 ? "Hemi" : "Hemi Sepolia";
+  const l1ChainId = chainId === 43111 ? 1 : 11155111;
+  const l1Address = extensions?.bridgeInfo?.[l1ChainId]?.tokenAddress;
+  return `
 <tr class="h-12 border-y">
   <td class="px-4 py-3">
     ${logo({ logoURI, name })}
     <span class="hidden lg:inline overflow-hidden whitespace-nowrap ml-2 text-ellipsis">${name}</span>
   </td>
   <td class="overflow-hidden whitespace-nowrap px-4 py-3 text-ellipsis">${symbol}</td>
-  <td class="overflow-hidden whitespace-nowrap px-4 py-3 text-ellipsis">${chainId === 43111 ? "Hemi" : "Hemi Sepolia"}</td>
+  <td class="overflow-hidden whitespace-nowrap px-4 py-3 text-ellipsis">${chainName}</td>
   <td class="px-4 py-3">
-    <a class="font-mono text-neutral-500 hover:text-neutral-700" href="https://${chainId === 43111 ? "explorer" : "testnet.explorer"}.hemi.xyz/token/${address}" title="${address}">
+    <a class="font-mono text-neutral-500 hover:text-neutral-700" href="${hemiExplorerUrl(chainId, address)}" title="${address}">
       ${shortenAddress(address)}
     </a>
   </td>
+  <td class="hidden lg:table-cell px-4 py-3">
+    ${
+      l1Address
+        ? `<a class="font-mono text-neutral-500 hover:text-neutral-700" href="${etherscanUrl(l1ChainId, l1Address)}" title="${l1Address}">
+            ${shortenAddress(l1Address)}
+          </a>`
+        : "-"
+    }
+  </td>
 </tr>
 `;
+}
 
 const page = ({ name, tokens, version }) => `
 <!DOCTYPE html>
@@ -81,6 +101,7 @@ const page = ({ name, tokens, version }) => `
           <th class="px-4 py-3 text-left font-normal">Symbol</th>
           <th class="px-4 py-3 text-left font-normal">Chain</th>
           <th class="px-4 py-3 text-left font-normal">Address</th>
+          <th class="px-4 py-3 text-left font-normal">L1 Address</th>
         </tr>
       </thead>
       <tbody>

--- a/scripts/build-ghp-index.js
+++ b/scripts/build-ghp-index.js
@@ -25,9 +25,10 @@ const etherscanUrl = (chainId, address) =>
 function row({ address, chainId, extensions, logoURI, name, symbol }) {
   const chainName = chainId === 43111 ? "Hemi" : "Hemi Sepolia";
   const l1ChainId = chainId === 43111 ? 1 : 11155111;
-  const l1Address = extensions?.bridgeInfo?.[l1ChainId]?.tokenAddress;
+  const l1Address = extensions?.bridgeInfo?.[l1ChainId]?.tokenAddress || "";
+  const rowId = `${name}${symbol}${address}${l1Address}`.toLowerCase();
   return `
-<tr class="h-12 border-y">
+<tr class="h-12 border-y" id="${rowId}">
   <td class="px-4 py-3">
     ${logo({ logoURI, name })}
     <span class="hidden lg:inline overflow-hidden whitespace-nowrap ml-2 text-ellipsis">${name}</span>
@@ -94,7 +95,8 @@ const page = ({ name, tokens, version }) => `
   <section class="flex flex-col items-center">
     <img class="my-12" src="assets/hemi-logo-orange.svg" height="131" width="132" alt="Hemi" />
     <h1 class="max-w-xl text-5xl text-center font-semibold">Explore tokens on the Hemi networks</h1>
-    <table class="max-w-full overflow-hidden mt-14 rounded-xl shadow-md">
+    <input class="border rounded-xl mt-8 px-4 py-2" id="searchInput" placeholder="Search"/>
+    <table class="max-w-full overflow-hidden mt-8 rounded-xl shadow-md">
       <thead class="hidden lg:table-header-group h-11 border-b bg-zinc-100">
         <tr>
           <th class="px-4 py-3 text-left font-normal">Name</th>
@@ -120,6 +122,17 @@ const page = ({ name, tokens, version }) => `
       </a>
     </p>
   </footer>
+
+  <script>
+    const searchInput = document.getElementById('searchInput');
+    searchInput.addEventListener('input', function (event) {
+      const query = event.target.value.toLowerCase();
+      const rows = document.querySelectorAll('tbody tr');
+      rows.forEach(function (row) {
+        row.style.display = row.id.includes(query) ? '' : 'none';
+      });
+    });
+  </script>
 </body>
 
 </html>

--- a/test/hemi.tokenlist.test.js
+++ b/test/hemi.tokenlist.test.js
@@ -121,12 +121,13 @@ describe("List of tokens", function () {
         const client = clients[chainId];
         const tokenAddress =
           extensions?.bridgeInfo?.[client.chain.sourceId].tokenAddress;
-        if (!tokenAddress) {
+        const remoteToken = await getRemoteToken(client, address).catch(
+          () => null,
+        );
+        if (!remoteToken) {
           this.skip();
           return;
         }
-
-        const remoteToken = await getRemoteToken(client, address);
         assert.equal(remoteToken, tokenAddress);
       });
     });

--- a/test/hemi.tokenlist.test.js
+++ b/test/hemi.tokenlist.test.js
@@ -124,10 +124,11 @@ describe("List of tokens", function () {
         const remoteToken = await getRemoteToken(client, address).catch(
           () => null,
         );
-        if (!remoteToken) {
+        if (!tokenAddress && !remoteToken) {
           this.skip();
           return;
         }
+
         assert.equal(remoteToken, tokenAddress);
       });
     });


### PR DESCRIPTION
This PR modifies the companion site to display the L1 address of each token (when available) and also adds an input box to search through the list.

https://github.com/user-attachments/assets/d25545d6-86bf-49bb-bf0a-9b362b316fda

There is no need to bump the package as this only modifies the site's code.