### PR TITLE
Separate OP and LayerZero bridge info via oft

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hemilabs/token-list",
-  "version": "2.9.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hemilabs/token-list",
-      "version": "2.9.0",
+      "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "21.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -777,7 +777,6 @@
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -777,6 +777,7 @@
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hemilabs/token-list",
-  "version": "2.9.0",
+  "version": "3.0.0",
   "description": "List of ERC-20 tokens in the Hemi chains",
   "bugs": {
     "url": "https://github.com/hemilabs/token-list/issues"

--- a/scripts/validate-list.js
+++ b/scripts/validate-list.js
@@ -36,6 +36,33 @@ async function validate() {
   schema.definitions.ExtensionPrimitiveValue.anyOf[l1LogoURIIndex].maxLength =
     100;
 
+  // The "oft" extension describes LayerZero bridging and is too deeply nested for
+  // the generic ExtensionValue schema, so it is validated with an explicit shape.
+  const addressPattern = "^0x[a-fA-F0-9]{40}$";
+  schema.definitions.ExtensionMap.properties = {
+    oft: {
+      additionalProperties: false,
+      properties: {
+        adapterAddress: { pattern: addressPattern, type: "string" },
+        peers: {
+          additionalProperties: {
+            additionalProperties: false,
+            properties: {
+              tokenAddress: { pattern: addressPattern, type: "string" },
+            },
+            required: ["tokenAddress"],
+            type: "object",
+          },
+          minProperties: 1,
+          propertyNames: { pattern: "^[0-9]+$" },
+          type: "object",
+        },
+      },
+      required: ["adapterAddress", "peers"],
+      type: "object",
+    },
+  };
+
   const validator = ajv.compile(schema);
   const valid = validator(tokenList);
   if (valid) {

--- a/src/hemi.tokenlist.json
+++ b/src/hemi.tokenlist.json
@@ -1,9 +1,9 @@
 {
   "name": "Hemi Token List",
-  "timestamp": "2026-06-04T20:51:28.904Z",
+  "timestamp": "2026-06-12T15:03:33.470Z",
   "version": {
-    "major": 2,
-    "minor": 9,
+    "major": 3,
+    "minor": 0,
     "patch": 0
   },
   "tokens": [

--- a/src/hemi.tokenlist.json
+++ b/src/hemi.tokenlist.json
@@ -377,22 +377,26 @@
         "bridgeInfo": {
           "1": {
             "tokenAddress": "0xEb964A1A6fAB73b8c72A0D15c7337fA4804F484d"
-          },
-          "10": {
-            "tokenAddress": "0x1aD02cD579C7668d50e0003f428701b70A1b42B7"
-          },
-          "56": {
-            "tokenAddress": "0x5fFD0EAdc186AF9512542d0d5e5eAFC65d5aFc5B"
-          },
-          "8453": {
-            "tokenAddress": "0xBcaBa0baC0F4Bff8cC8659F2218C6d5324b46061"
-          },
-          "42161": {
-            "tokenAddress": "0x1f278B7EFf04ADd48Ff81ae1a01cBC178b3dD351"
           }
         },
         "l1LogoURI": "https://hemilabs.github.io/token-list/l1Logos/hemi.svg",
-        "oftAdapterAddress": "0xf14A494Fb66927Df0b1495E5F09b410e5D8517C3"
+        "oft": {
+          "adapterAddress": "0xf14A494Fb66927Df0b1495E5F09b410e5D8517C3",
+          "peers": {
+            "10": {
+              "tokenAddress": "0x1aD02cD579C7668d50e0003f428701b70A1b42B7"
+            },
+            "56": {
+              "tokenAddress": "0x5fFD0EAdc186AF9512542d0d5e5eAFC65d5aFc5B"
+            },
+            "8453": {
+              "tokenAddress": "0xBcaBa0baC0F4Bff8cC8659F2218C6d5324b46061"
+            },
+            "42161": {
+              "tokenAddress": "0x1f278B7EFf04ADd48Ff81ae1a01cBC178b3dD351"
+            }
+          }
+        }
       },
       "logoURI": "https://hemilabs.github.io/token-list/logos/hemi.svg",
       "name": "Hemi",
@@ -416,12 +420,27 @@
       "decimals": 8,
       "extensions": {
         "birthBlock": 1125154,
-        "bridgeInfo": {
-          "1": {
-            "tokenAddress": "0x06ea695B91700071B161A434fED42D1DcbAD9f00"
+        "l1LogoURI": "https://hemilabs.github.io/token-list/l1Logos/hemibtc.svg",
+        "oft": {
+          "adapterAddress": "0xDefa4A253a0Ec96a2e6D74A409B3B348924bf390",
+          "peers": {
+            "1": {
+              "tokenAddress": "0x06ea695B91700071B161A434fED42D1DcbAD9f00"
+            },
+            "10": {
+              "tokenAddress": "0xB5259c05764468c33C9c36e327cAAD020a8E5Fe1"
+            },
+            "56": {
+              "tokenAddress": "0x64b5bb3b7eF0267019fee5b826c60Cb9B7609373"
+            },
+            "8453": {
+              "tokenAddress": "0xC6FFfA0E234E5Ec80B8654Cb351dA90A092F6C95"
+            },
+            "42161": {
+              "tokenAddress": "0x1855911ab07ed5Cd056008F409b709DfA9D01183"
+            }
           }
-        },
-        "l1LogoURI": "https://hemilabs.github.io/token-list/l1Logos/hemibtc.svg"
+        }
       },
       "logoURI": "https://hemilabs.github.io/token-list/logos/hemibtc.svg",
       "name": "Hemi Bitcoin",

--- a/src/hemi.tokenlist.json
+++ b/src/hemi.tokenlist.json
@@ -416,6 +416,11 @@
       "decimals": 8,
       "extensions": {
         "birthBlock": 1125154,
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x06ea695B91700071B161A434fED42D1DcbAD9f00"
+          }
+        },
         "l1LogoURI": "https://hemilabs.github.io/token-list/l1Logos/hemibtc.svg"
       },
       "logoURI": "https://hemilabs.github.io/token-list/logos/hemibtc.svg",

--- a/test/hemi.tokenlist.test.js
+++ b/test/hemi.tokenlist.test.js
@@ -9,6 +9,8 @@ import {
   http,
   isAddress,
 } from "viem";
+import { readContract } from "viem/actions";
+import { arbitrum, base, bsc, mainnet, optimism } from "viem/chains";
 
 import { getRemoteToken } from "../scripts/get-remote-token.js";
 
@@ -17,15 +19,44 @@ const tokenList = JSON.parse(
   fs.readFileSync("./src/hemi.tokenlist.json", "utf-8"),
 );
 
+// A client per chain, keyed by chain id: the Hemi chains where tokens live plus
+// the chains a LayerZero-bridged token can reach to read its remote OFT peer.
+// Cap each request at 5s and disable retries so an unresponsive or rate-limited
+// public RPC fails fast instead of hanging on retry/Retry-After backoff. The
+// default mainnet RPC is unreliable, so use an explicit endpoint there.
+const rpcUrls = { [mainnet.id]: "https://eth.drpc.org" };
 const clients = Object.fromEntries(
-  [hemi, hemiSepolia].map((chain) => [
+  [hemi, hemiSepolia, mainnet, optimism, bsc, base, arbitrum].map((chain) => [
     chain.id,
     createPublicClient({
       chain,
-      transport: http(),
+      transport: http(rpcUrls[chain.id], { retryCount: 0, timeout: 5000 }),
     }),
   ]),
 );
+
+// LayerZero V2 endpoint ID for Hemi. Remote OFTs peer back to the Hemi adapter
+// using this id.
+const hemiEndpointId = 30329;
+
+const peersAbi = [
+  {
+    type: "function",
+    name: "peers",
+    stateMutability: "view",
+    inputs: [{ type: "uint32" }],
+    outputs: [{ type: "bytes32" }],
+  },
+];
+const tokenAbi = [
+  {
+    type: "function",
+    name: "token",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "address" }],
+  },
+];
 
 describe("Version", function () {
   it("should match the package version", function () {
@@ -58,18 +89,16 @@ describe("List of tokens", function () {
 
     describe(`Token ${chainId}:${address} (${symbol})`, function () {
       it("should have all its addresses in the checksum format", function () {
-        assert.ok(isAddress(address) && checksumAddress(address) === address);
+        const isChecksummed = (value) =>
+          isAddress(value) && checksumAddress(value) === value;
+        assert.ok(isChecksummed(address));
         Object.values(extensions.bridgeInfo ?? {}).forEach(({ tokenAddress }) =>
-          assert.ok(
-            isAddress(tokenAddress) &&
-              checksumAddress(tokenAddress) === tokenAddress,
-          ),
+          assert.ok(isChecksummed(tokenAddress)),
         );
-        if (extensions.oftAdapterAddress) {
-          assert.ok(
-            isAddress(extensions.oftAdapterAddress) &&
-              checksumAddress(extensions.oftAdapterAddress) ===
-                extensions.oftAdapterAddress,
+        if (extensions.oft) {
+          assert.ok(isChecksummed(extensions.oft.adapterAddress));
+          Object.values(extensions.oft.peers).forEach(({ tokenAddress }) =>
+            assert.ok(isChecksummed(tokenAddress)),
           );
         }
       });
@@ -143,6 +172,41 @@ describe("List of tokens", function () {
         }
 
         assert.equal(remoteToken, tokenAddress);
+      });
+
+      it("should have valid LayerZero OFT peers", async function () {
+        const { oft } = extensions;
+        if (!oft) {
+          this.skip();
+          return;
+        }
+
+        // The Hemi-side OFT adapter must wrap this token.
+        const adapterToken = await readContract(clients[chainId], {
+          abi: tokenAbi,
+          address: oft.adapterAddress,
+          args: [],
+          functionName: "token",
+        });
+        assert.equal(adapterToken, address);
+
+        // Every peer OFT must point back to the Hemi adapter.
+        for (const [remoteChainId, { tokenAddress }] of Object.entries(
+          oft.peers,
+        )) {
+          const client = clients[remoteChainId];
+          assert.ok(client, `no client configured for chain ${remoteChainId}`);
+          const peer = await readContract(client, {
+            abi: peersAbi,
+            address: tokenAddress,
+            args: [hemiEndpointId],
+            functionName: "peers",
+          });
+          assert.equal(
+            checksumAddress(`0x${peer.slice(-40)}`),
+            oft.adapterAddress,
+          );
+        }
       });
     });
   });


### PR DESCRIPTION
## Description

Originally this PR just added hemiBTC's mainnet bridge address. While wiring up the on-chain test for it we found that hemiBTC is bridged via **LayerZero (OFT)**, not the **OP standard bridge** that the existing `bridgeInfo` extension models. Overloading `bridgeInfo` with both bridge types didn't scale and was ambiguous (e.g. HEMI is OP-bridged to mainnet but LayerZero-bridged to op/bnb/base/arb).

So this PR introduces a dedicated `oft` extension and splits the two bridge types cleanly:

```jsonc
"extensions": {
  "bridgeInfo": { /* OP standard bridge: chainId -> { tokenAddress } */ },
  "oft": {                          // LayerZero
    "adapterAddress": "0x…",        // OFT adapter on Hemi (wraps the token)
    "peers": { "<chainId>": { "tokenAddress": "0x…" } }
  }
}
```

### Changes

- **`src/hemi.tokenlist.json`**
  - **hemiBTC**: LayerZero-only, so it has no `bridgeInfo`; all peers (eth/op/bnb/base/arb) live under `oft`.
  - **HEMI**: keeps its OP mainnet entry in `bridgeInfo` and moves its op/bnb/base/arb routes to `oft`. The old `oftAdapterAddress` field is removed.
- **`scripts/validate-list.js`**: validates the `oft` shape (only `adapterAddress` + `peers{chainId:{tokenAddress}}`, checksummable hex addresses), since it is too deeply nested for the generic Uniswap `ExtensionValue` schema.
- **`test/hemi.tokenlist.test.js`**: new `should have valid LayerZero OFT peers` test that verifies peering on-chain — the adapter's `token()` must equal the listed token, and every peer's `peers(<HemiEID>)` must point back to the adapter. The OP `remote token address` test is restored to its original form (OP tokens read their L1 address from the Hemi-side contract). Because the peers test queries each remote chain directly, clients disable retries with a 5s timeout (fail fast instead of hanging on a rate-limited RPC) and pin mainnet to a reliable endpoint.

### Why 3.0.0 (major)

This is a **breaking schema change** for consumers of the token list:

- `extensions.oftAdapterAddress` is removed (now `extensions.oft.adapterAddress`).
- `extensions.bridgeInfo` no longer carries LayerZero routes — for LayerZero tokens like hemiBTC it is now absent entirely, with that data under `extensions.oft.peers`.

Anything reading `bridgeInfo` to resolve a LayerZero token's remote address, or reading `oftAdapterAddress`, must migrate to `oft`. Per semver that warrants a major bump, so the list and package move from 2.x to **3.0.0**.

Related to hemilabs/ui-monorepo#1848
Related to hemilabs/ui-monorepo#1973

**Commits:**

- 3c144f6 Add hemiBTC mainnet bridge address
- 544e705 Add oft extension for LayerZero bridge info
- 462fd0f 3.0.0