### PR TITLE
Expose hemiBTC token as hemibtc.json

### DIFF
--- a/scripts/build-ghp.sh
+++ b/scripts/build-ghp.sh
@@ -14,3 +14,6 @@ node scripts/build-ghp-index.js
 
 # Extract hemi.json
 jq '.tokens[] | select(.symbol == "HEMI" and .chainId == 43111)' src/hemi.tokenlist.json >public/hemi.json
+
+# Extract hemibtc.json
+jq '.tokens[] | select(.symbol == "hemiBTC" and .chainId == 43111)' src/hemi.tokenlist.json >public/hemibtc.json


### PR DESCRIPTION
## Description

Just like we expose the HEMI token as `hemi.json`, we now need to expose hemiBTC as well.

This adds an extraction step to `scripts/build-ghp.sh` that selects the hemiBTC token from Hemi mainnet (chain 43111) and writes it to `public/hemibtc.json`, mirroring the existing HEMI extraction in the GitHub Pages build.

No related issue.