### PR TITLE
Add sVUSD (Hemi) token

### DIFF
--- a/docs/add-new-token.md
+++ b/docs/add-new-token.md
@@ -42,9 +42,6 @@ The script will automatically add the information about the new token to [./src/
     "address": "0x0C8aFD1b58aa2A5bAd2414B861D8A7fF898eDC3A",
     "chainId": 743111,
     "decimals": 18,
-    "extensions": {
-      "l1LogoURI": "https://hemilabs.github.io/token-list/l1Logos/weth.svg",
-    },
     "logoURI": "https://hemilabs.github.io/token-list/logos/weth.svg",
     "name": "Wrapped Ether",
     "symbol": "WETH"
@@ -62,11 +59,11 @@ If you pay attention to the information added by the script in the previous step
 
 > The token logo can be an SVG or PNG file (it sets `svg` as default in the `logoURI`, but you can change it to `png` if needed).
 
-In addition to that, in the extensions field, a L1 logo version is added that does not include the Hemi logo in it. These logos shall be added to the [./src/l1Logos](../src/l1Logos) directory.
+Optionally, you can also add a L1 logo version that does not include the Hemi logo in it. This logo file shall be added to the [./src/l1Logos](../src/l1Logos) directory and referenced manually via the `l1LogoURI` extension (the `add-token` script does not add it for you).
 
 ```json
 "extensions": {
-  "logoURI": "https://hemilabs.github.io/token-list/l1Logos/weth.svg",
+  "l1LogoURI": "https://hemilabs.github.io/token-list/l1Logos/weth.svg",
 }
 ```
 

--- a/docs/add-new-token.md
+++ b/docs/add-new-token.md
@@ -63,7 +63,7 @@ In addition to the L2 logo, you must add a L1 logo version that does not include
 
 ```json
 "extensions": {
-  "l1LogoURI": "https://hemilabs.github.io/token-list/l1Logos/weth.svg",
+  "l1LogoURI": "https://hemilabs.github.io/token-list/l1Logos/weth.svg"
 }
 ```
 

--- a/docs/add-new-token.md
+++ b/docs/add-new-token.md
@@ -59,7 +59,7 @@ If you pay attention to the information added by the script in the previous step
 
 > The token logo can be an SVG or PNG file (it sets `svg` as default in the `logoURI`, but you can change it to `png` if needed).
 
-Optionally, you can also add a L1 logo version that does not include the Hemi logo in it. This logo file shall be added to the [./src/l1Logos](../src/l1Logos) directory and referenced manually via the `l1LogoURI` extension (the `add-token` script does not add it for you).
+In addition to the L2 logo, you must add a L1 logo version that does not include the Hemi logo in it. This logo file shall be added to the [./src/l1Logos](../src/l1Logos) directory and referenced manually via the `l1LogoURI` extension (the `add-token` script does not add it for you).
 
 ```json
 "extensions": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hemilabs/token-list",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "List of ERC-20 tokens in the Hemi chains",
   "bugs": {
     "url": "https://github.com/hemilabs/token-list/issues"

--- a/src/hemi.tokenlist.json
+++ b/src/hemi.tokenlist.json
@@ -652,6 +652,18 @@
       "symbol": "uniBTC"
     },
     {
+      "address": "0xfe875CC86cC6BC2E93ab330D6b2c408C3Cd79710",
+      "chainId": 43111,
+      "decimals": 18,
+      "extensions": {
+        "birthBlock": 4034164,
+        "l1LogoURI": "https://hemilabs.github.io/token-list/l1Logos/svusd.svg"
+      },
+      "logoURI": "https://hemilabs.github.io/token-list/logos/svusd.svg",
+      "name": "Staked Vetro USD",
+      "symbol": "sVUSD"
+    },
+    {
       "address": "0x0C8aFD1b58aa2A5bAd2414B861D8A7fF898eDC3A",
       "chainId": 743111,
       "decimals": 18,

--- a/src/hemi.tokenlist.json
+++ b/src/hemi.tokenlist.json
@@ -1,9 +1,9 @@
 {
   "name": "Hemi Token List",
-  "timestamp": "2026-06-12T15:03:33.470Z",
+  "timestamp": "2026-06-15T14:59:01.502Z",
   "version": {
     "major": 3,
-    "minor": 0,
+    "minor": 1,
     "patch": 0
   },
   "tokens": [


### PR DESCRIPTION
## Summary
- Add the **sVUSD** (`Staked Vetro USD`) token on Hemi mainnet (chainId `43111`), address [`0xfe875CC86cC6BC2E93ab330D6b2c408C3Cd79710`](https://explorer.hemi.xyz/address/0xfe875CC86cC6BC2E93ab330D6b2c408C3Cd79710). 18 decimals, no bridge (Hemi-native, mirrors `svetBTC`). Includes `birthBlock` `4034164` and `l1LogoURI`; both logos were already present in `src/logos` and `src/l1Logos`.
- While verifying `docs/add-new-token.md`, fixed it to match the actual `add-token.js` behavior: the script does not auto-add `l1LogoURI` (removed from the Step 1 example), and corrected the Step 2 extension field name from `logoURI` to `l1LogoURI`, clarifying it is an optional manual step.

Closes #109

## Test plan
- [x] `pnpm test` (includes `schema:validate`) — 0 failures
- [x] `pnpm run format:check` — clean
- [x] `pnpm version minor` → 3.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)